### PR TITLE
Remove needless quotes

### DIFF
--- a/lacquer.el
+++ b/lacquer.el
@@ -115,8 +115,8 @@ Optional: config.Any function."
   "Mode of switch theme automatically."
   :group 'lacquer
   :type '(choice
-          (const :tag "Orderly" 'orderly)
-          (const :tag "Random" 'random)))
+          (const :tag "Orderly" orderly)
+          (const :tag "Random" random)))
 
 
 (defcustom lacquer-auto-switch-time (lacquer-time-word-seconds 1 "hour")


### PR DESCRIPTION
They are already quoted. And this change fixes the following byte-compile warning. 

```
lacquer.el:114:12: Warning: defcustom for ‘lacquer-auto-switch-mode’ has
    syntactically odd type ‘'(choice (const :tag Orderly 'orderly) (const :tag
    Random 'random))’
```